### PR TITLE
fix: unhandled promise rejections while creating session

### DIFF
--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -248,6 +248,17 @@ export function isInstanceNotFoundError(
 }
 
 /**
+ * Checks whether the given error is an 'Create session permission' error.
+ * @param {Error} error The error to check.
+ * @return {boolean} True if the error is an 'Create session permission' error, and otherwise false.
+ */
+export function isCreateSessionPermissionError(
+  error: grpc.ServiceError | undefined
+): boolean {
+  return error !== undefined && error.code === grpc.status.PERMISSION_DENIED;
+}
+
+/**
  * enum to capture errors that can appear from multiple places
  */
 const enum errors {
@@ -558,7 +569,11 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
     this._fill().catch(err => {
       // Ignore `Database not found` error. This allows a user to call instance.database('db-name')
       // for a database that does not yet exist with SessionPoolOptions.min > 0.
-      if (isDatabaseNotFoundError(err) || isInstanceNotFoundError(err)) {
+      if (
+        isDatabaseNotFoundError(err) ||
+        isInstanceNotFoundError(err) ||
+        isCreateSessionPermissionError(err)
+      ) {
         return;
       }
       this.emit('error', err);

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -255,7 +255,11 @@ export function isInstanceNotFoundError(
 export function isCreateSessionPermissionError(
   error: grpc.ServiceError | undefined
 ): boolean {
-  return error !== undefined && error.code === grpc.status.PERMISSION_DENIED;
+  return (
+    error !== undefined &&
+    error.code === grpc.status.PERMISSION_DENIED &&
+    error.message.includes('spanner.sessions.create')
+  );
 }
 
 /**


### PR DESCRIPTION
Issue: 1319

Here is the different scenarios on how it handles the exception.

**Non existing Table:**
`5 NOT_FOUND: Table not found: fake-table-name`
Properly Handles the exception.

**Non existing Database:**
`5 NOT_FOUND: Database not found: projects/existing-project/instances/existing-instance/databases/fake-database-id`
Properly Handles the exception.

**Non existing Instance:**
`5 NOT_FOUND: Instance not found: projects/existing-project/instances/fake-instance-id`
Properly Handles the exception.

**Non existing Project:**
`7 PERMISSION_DENIED: Caller is missing IAM permission spanner.sessions.create on resource projects/fake-projectId/instances/existing-instance-id/databases/existing-database-id.`
It gives the error as well as throws `UnhandledPromiseRejectionWarning` exception.

While creating the session if Project doesn't exists it gives the above error as well has throws the `UnhandledPromiseRejectionWarning` exception.

**Propose Implementation:**
stop re-emitting the `spanner.sessions.create` permission error as it's already been emitted in [_fill method's catch block](https://github.com/googleapis/nodejs-spanner/blob/ffb88bbf2f9d2c7c0c5adea7953006b6a25d8f22/src/session-pool.ts#L859).